### PR TITLE
Refactor text-format utils to replace format with style

### DIFF
--- a/colint/clean_jupyter/clean_jupyter.py
+++ b/colint/clean_jupyter/clean_jupyter.py
@@ -2,25 +2,25 @@ from pathlib import Path
 
 from ..utils.jupyter_utils import JupyterNotebokParser
 from ..utils.os_utils import get_valid_files
-from ..utils.text_formatting_utils import TextModifiers, format_text
+from ..utils.text_styling_utils import TextModifiers, style_text
 
 
-def __format_text(fname: str | Path, only_check: bool) -> str:
+def __style_text(fname: str | Path, only_check: bool) -> str:
     """
-    Format the file name for display.
+    Styles the file name for display.
 
     Args:
         fname (str | Path): The name or path of the file.
         only_check (bool): If True, returns a message indicating the file hasn't been cleared of outputs. Otherwise, indicates the file has been cleared.
 
     Returns:
-        str: A formatted string indicating the status of the file's outputs.
+        str: A styled string indicating the status of the file's outputs.
     """
-    formatted_fname = format_text(str(Path(fname).resolve()), TextModifiers.BOLD)
+    styled_fname = style_text(str(Path(fname).resolve()), TextModifiers.BOLD)
 
     if only_check:
-        return f"{formatted_fname}: has not been cleared of its outputs."
-    return f"{formatted_fname}: has been cleared of its outputs."
+        return f"{styled_fname}: has not been cleared of its outputs."
+    return f"{styled_fname}: has been cleared of its outputs."
 
 
 def __clean_notebook(fname: str | Path, only_check: bool) -> bool:
@@ -65,5 +65,5 @@ def jupyter_clean(path: str, only_check: bool) -> bool:
         nb_modified = __clean_notebook(fname_nb, only_check)
         if nb_modified:
             modified = True
-            print(__format_text(fname_nb, only_check))
+            print(__style_text(fname_nb, only_check))
     return modified

--- a/colint/code_format/code_format.py
+++ b/colint/code_format/code_format.py
@@ -5,7 +5,7 @@ from black import Mode, format_file_contents
 from ..params.black_params import BlackParams
 from ..utils.jupyter_utils import JupyterNotebokParser
 from ..utils.os_utils import get_valid_files
-from ..utils.text_formatting_utils import TextModifiers, format_text
+from ..utils.text_styling_utils import TextModifiers, style_text
 
 
 def __get_black_mode(params: BlackParams) -> Mode:
@@ -26,23 +26,23 @@ def __get_black_mode(params: BlackParams) -> Mode:
     )
 
 
-def __format_black_message(fname: str | Path, only_check: bool) -> str:
+def __style_black_message(fname: str | Path, only_check: bool) -> str:
     """
-    Format a message indicating whether a file would have been or has been reformatted.
+    Styles a message indicating whether a file would have been or has been reformatted.
 
     Args:
         fname (str | Path): The file name.
         only_check (bool): Whether the formatter is running in "check only" mode.
 
     Returns:
-        str: A formatted message string.
+        str: A styled message string.
     """
-    formatted_fname = format_text(str(Path(fname).resolve()), TextModifiers.BOLD)
+    styled_fname = style_text(str(Path(fname).resolve()), TextModifiers.BOLD)
 
     if only_check:
-        return f"{formatted_fname}: would have been reformatted."
+        return f"{styled_fname}: would have been reformatted."
     else:
-        return f"{formatted_fname}: has been reformatted"
+        return f"{styled_fname}: has been reformatted"
 
 
 def format_notebook(nb_path: str | Path, only_check: bool, mode: Mode) -> bool:
@@ -115,12 +115,12 @@ def format_code(path: str, only_check: bool, params: BlackParams) -> bool:
         modified = format_script(file, only_check, mode)
         any_file_not_linted |= modified
         if modified:
-            print(__format_black_message(file, only_check))
+            print(__style_black_message(file, only_check))
 
     for file in notebook_files:
         modified = format_notebook(file, only_check, mode)
         any_file_not_linted |= modified
         if modified:
-            print(__format_black_message(file, only_check))
+            print(__style_black_message(file, only_check))
 
     return any_file_not_linted

--- a/colint/grammar_libraries/flake8error.py
+++ b/colint/grammar_libraries/flake8error.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 
-from ..utils.text_formatting_utils import TextModifiers, format_text
+from ..utils.text_styling_utils import TextModifiers, style_text
 
 
 class Flake8Error:
     """
-    A class to represent a Flake8 error and provide methods for formatting
+    A class to represent a Flake8 error and provide methods for styling
     and determining if it should be ignored.
 
     Attributes:
@@ -32,19 +32,19 @@ class Flake8Error:
 
     def to_str(self) -> str:
         """
-        Convert the Flake8Error instance to a formatted string.
+        Convert the Flake8Error instance to a styled string.
 
         Returns:
-            str: A string representation of the Flake8 error with formatting.
+            str: A string representation of the Flake8 error with styling.
         """
-        cell_format_list = []
+        cell_styled_list = []
         if self.cell_number:
-            cell_format_list = [format_text(f"Cell{self.cell_number}", TextModifiers.INVERSE)]
-        path_formatted = ":".join(
-            [str(Path(self.filename).resolve())] + cell_format_list + [str(self.line_number), str(self.col_number)]
+            cell_styled_list = [style_text(f"Cell{self.cell_number}", TextModifiers.INVERSE)]
+        path_styled = ":".join(
+            [str(Path(self.filename).resolve())] + cell_styled_list + [str(self.line_number), str(self.col_number)]
         )
-        code_formatted = format_text(self.code, [TextModifiers.ERROR, TextModifiers.BOLD])
-        return f"{code_formatted} {path_formatted} - {self.message}"
+        code_styled = style_text(self.code, [TextModifiers.ERROR, TextModifiers.BOLD])
+        return f"{code_styled} {path_styled} - {self.message}"
 
     def should_be_ignored(self, ignore: list[str] = [], per_file_ignores: dict[str, list[str]] = {}) -> bool:
         """

--- a/colint/newline_fix/newline_fix.py
+++ b/colint/newline_fix/newline_fix.py
@@ -1,15 +1,15 @@
 from pathlib import Path
 
 from ..utils.os_utils import get_valid_files
-from ..utils.text_formatting_utils import TextModifiers, format_text
+from ..utils.text_styling_utils import TextModifiers, style_text
 
 
-def __format_text(fname: str | Path, only_check: bool) -> str:
-    formatted_fname = format_text(str(Path(fname).resolve()), TextModifiers.BOLD)
+def __style_text(fname: str | Path, only_check: bool) -> str:
+    styled_fname = style_text(str(Path(fname).resolve()), TextModifiers.BOLD)
     if only_check:
-        return f"{formatted_fname}: No newline at the end of file!"
+        return f"{styled_fname}: No newline at the end of file!"
     else:
-        return f"{formatted_fname}: Added newline at the end of file."
+        return f"{styled_fname}: Added newline at the end of file."
 
 
 def newline_fix(path: str, only_check: bool = False):
@@ -25,7 +25,7 @@ def newline_fix(path: str, only_check: bool = False):
             modified |= newline_missing
 
             if newline_missing:
-                print(__format_text(fname, only_check))
+                print(__style_text(fname, only_check))
             if newline_missing and not only_check:
                 f.write(b"\n")
     return modified

--- a/colint/sort_libraries/sorter.py
+++ b/colint/sort_libraries/sorter.py
@@ -6,17 +6,17 @@ import isort
 from ..params.isort_params import IsortParams
 from ..utils.jupyter_utils import JupyterNotebokParser
 from ..utils.os_utils import get_valid_files
-from ..utils.text_formatting_utils import TextModifiers, format_text
+from ..utils.text_styling_utils import TextModifiers, style_text
 
 FILE_SORTED_MESSAGE = "! File has been sorted: "
 FILE_NOT_SORTED_MESSAGE = "! File has not been sorted: "
 
 
-def generate_message(f: Path, only_check: bool) -> str:
-    formatted_filename = format_text(str(f.resolve()), TextModifiers.BOLD)
+def __style_message(f: Path, only_check: bool) -> str:
+    styled_fname = style_text(str(f.resolve()), TextModifiers.BOLD)
     if only_check:
-        return format_text(FILE_NOT_SORTED_MESSAGE, TextModifiers.ERROR) + formatted_filename
-    return FILE_SORTED_MESSAGE + formatted_filename
+        return style_text(FILE_NOT_SORTED_MESSAGE, TextModifiers.ERROR) + styled_fname
+    return FILE_SORTED_MESSAGE + styled_fname
 
 
 def __isort_text(text: str, params: IsortParams) -> tuple[str, bool]:
@@ -104,13 +104,13 @@ def sort_imports(path: str, only_check: bool, params: IsortParams) -> bool:
             file_not_linted = isort.file(f, profile=params.profile)
         some_file_has_been_sorted = some_file_has_been_sorted or file_not_linted
         if file_not_linted:
-            print(generate_message(f, only_check))
+            print(__style_message(f, only_check))
 
     # Process Jupyter notebook files
     for f in notebook_files:
         file_not_linted = __isort_jupyter_notebook(str(f), only_check, params)
         some_file_has_been_sorted = some_file_has_been_sorted or file_not_linted
         if file_not_linted:
-            print(generate_message(f, only_check))
+            print(__style_message(f, only_check))
 
     return some_file_has_been_sorted

--- a/colint/utils/text_styling_utils.py
+++ b/colint/utils/text_styling_utils.py
@@ -9,19 +9,19 @@ class TextModifiers:
     INVERSE = 44  # swap background & text color
 
 
-def format_text(text: str, codes: int | list[int]) -> str:
+def style_text(text: str, codes: int | list[int]) -> str:
     """
-    Returns a formatted version of the input text. Automatically includes an end formatting character
+    Returns a styled version of the input text. Automatically includes an end styling character
     at the end of the string.
 
     Parameters:
-    text (str): The text to be formatted
-    codes (int | list[int]): formatting codes to be used in the text.
+    text (str): The text to be styled
+    codes (int | list[int]): styling codes to be used in the text.
                              Refer to TextModifiers for the useful codes.
                              if a list is passed all modifiers are applied
 
     Returns:
-    formatted_text: the formatted text
+    styled_text: the styled text
     """
     if isinstance(codes, int):
         codes = [codes]


### PR DESCRIPTION
Refactored the `text_formatting_utils.py` module to enhance readability and maintain consistency in terminology. All instances of 'format' have been replaced with 'style'. This change affects function names, variable names, comments, and documentation.

No functional changes have been made to the underlying logic.