### PR TITLE
Add experimental docformatter to colint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ usage: colint [-h] [--check] [--clean-notebooks]
   - `newline-fix`: Fixes newline inconsistencies in the files.
   - `clean-jupyter`: Cleans Jupyter notebook files by removing unnecessary metadata and outputs.
   - `lint`: Performs all the above operations except `clean-jupyter`. To include `clean-jupyter`, use the `--clean-notebooks` flag.
+  - `docformat`: **Experimental** Formats docstrings and commented lines to adhere to the google docstring standard, breaks lines so that 
+    their length adheres to the style guide. Please read the section "Experimental Commands" before using this.
 
 - `path_to_dir`: Provide the path to the directory that needs linting.
 
@@ -110,6 +112,20 @@ colint lint /path/to/your/project --clean-notebooks
 ```sh
 colint grammar-check /path/to/your/project
 ```
+
+### Experimental Commands
+
+The following commands are right now **experimental** and are not meant to be used in a production environment:
+- `docformat`
+
+**Docformat**
+Formats a document so that it adheres the google (and only google!) docstring standard. It will break lines so that their length is the same as
+the one you have set in the style guide. It will try to "guess" the indentation of each paragraph.
+
+__If there are multiple indentation levels in the same paragraph, it will remove them__
+
+The command will work only on a single file at the time, because you should always check "by hand" the results of the doc-formatting, and you
+__should not take the results as granted__.
 
 ## Contributing
 Contributions are welcome! Please feel free to open issues or submit pull requests.

--- a/colint/colinter.py
+++ b/colint/colinter.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from .clean_jupyter.clean_jupyter import jupyter_clean
 from .code_format.code_format import format_code
+from .docformat.docformat import docformat
 from .grammar_libraries.grammar_check import code_check
 from .newline_fix.newline_fix import newline_fix
 from .params.params import Params
@@ -63,12 +64,6 @@ def main():
 
     This function serves as the starting point for the script.
     It initializes the process and coordinates the overall workflow.
-
-    Args:
-        None
-
-    Returns:
-        None
     """
     arg_parser = argparse.ArgumentParser(
         description="Handles various commands related to directories and notebooks.",
@@ -86,6 +81,7 @@ def main():
             "  - newline-fix: Fixes newline inconsistencies in the files.\n"
             "  - clean-jupyter: Cleans Jupyter notebook files by removing unnecessary metadata and outputs.\n"
             '  - lint: Performs all the operations above, but "clean-jupyter". To also use "clean-jupyter" use the --clean-notebooks flag.'
+            "  - docformat: performs an **experimental** docformatting over a file. NOTE: it only works on a single file."
         ),
     )
     arg_parser.add_argument(
@@ -120,6 +116,14 @@ def main():
     if not lint_dir.is_dir() and not lint_dir.is_file():
         print(f"Error: Path to directory '{lint_dir}' is not valid.")
         sys.exit(1)
+
+    if command == "docformat" and not lint_dir.is_file():
+        print("Error! docformat only works on a single file.")
+        sys.exit(1)
+
+    if command == "docformat":
+        docformat(lint_dir, params.black)
+        sys.exit(0)
 
     if command != "lint":
         res = perform_operation(command, str(lint_dir.resolve()), only_check)

--- a/colint/docformat/apply_google_style.py
+++ b/colint/docformat/apply_google_style.py
@@ -1,0 +1,249 @@
+import re
+from dataclasses import dataclass, field
+
+from .format_text import format_text_with_prefix
+
+
+@dataclass
+class ListElement:
+    """Represents a list element in a formatted docstring.
+
+    A  list  element  consists  of  a  heading  and line. Heading is whatever is used to
+    introduce  the  element.  For example, it could be a symbol (e.g. "7-"), or a number
+    (e.g.  "7.") or even the name of a variable with its typing (e.g. "heading (str)" as
+    below). Lines is the element actual content.
+
+    Attributes:
+        heading (str): The heading of the element.
+        lines (list[str]): The content lines after the element heading.
+    """
+
+    heading: str = ""
+    lines: list[str] = field(default_factory=lambda: [])
+
+
+@dataclass
+class Section:
+    """Represents a section in a formatted docstring.
+
+    A  section  can  possibly contain a heading, a list of content lines, and possibly a
+    list of subsections.
+
+    Attributes:
+        title_summary_section (bool): Indicates  if  this  section contains the title or
+            summary.
+        lines (list[str]): The main content lines of the section.
+        heading (str | None): The  heading  for  the section (if applicable).Not used if
+            title_summary_section is True.
+        list_elements (list[ListElement]): The  elements within the section. Not used if
+            title_summary_section is True.
+    """
+
+    title_summary_section: bool = True
+    lines: list[str] = field(default_factory=lambda: [])
+    heading: str | None = None
+    list_elements: list[ListElement] = field(default_factory=lambda: [])
+
+
+__google_docs_section_keys = [
+    "Args",
+    "Returns",
+    "Raises",
+    "Attributes",
+    "Yields",
+    "Examples",
+    "See Also",
+    "Notes",
+    "Warnings",
+    "References",
+    "Deprecated",
+    "TODO",
+]
+
+__google_docs_section_patterns = [
+    re.compile(f"^{s}\\s*:$", re.IGNORECASE) for s in __google_docs_section_keys
+]
+
+
+def __get_google_doc_heading(line: str) -> str | None:
+    """Returns heading if the given line matches a Google-style docstring heading.
+
+    Args:
+        line (str): A single line from the docstring.
+
+    Returns:
+        str | None: The matched section heading if found, otherwise None.
+    """
+    idx = -1
+    for k, pattern in enumerate(__google_docs_section_patterns):
+        if pattern.match(line.strip()):
+            idx = k
+            break
+    if idx < 0:
+        return None
+    return f"{__google_docs_section_keys[idx]}:"
+
+
+__parameter_pattern = re.compile(r"^\*{0,2}\w+\s*(\([^)]*\))?\s*:")
+__datatype_pattern = re.compile(r"^\w+\s*(\[[^)]*\])?\s*:")
+__list_element_pattern = re.compile(r"^(-|\d+\.)")
+
+
+def __is_parameter_explaining(line: str) -> tuple[str | None, str | None]:
+    """Identifies whether a line in the docstring is a list element.
+
+    Args:
+        line (str): A single line from the docstring.
+
+    Returns:
+        tuple[str | None, str | None]: The list element heading and the rest of the line
+            text (if any), otherwise (None, None).
+    """
+    line = line.strip()
+    match = __parameter_pattern.match(line)
+    if match:
+        value = match.group()[:-1].strip()
+        value = " ".join(value.split())
+        value += ":"
+        return value, line[match.end() :].strip()
+    match = __datatype_pattern.match(line)
+    if match:
+        value = match.group()[:-1].strip()
+        if "[" in value:
+            name = value.split("[")[0].strip()
+            value = name + value[len(name) :].strip()
+        value += ":"
+        return value, line[match.end() :].strip()
+    match = __list_element_pattern.match(line)
+    if match:
+        return match.group().strip(), line[match.end() :].strip()
+    return None, None
+
+
+def __divide_into_sections(lines: list[str]) -> list[Section]:
+    """Divides the docstring lines into sections and subsections.
+
+    Args:
+        lines (list[str]): The lines from the docstring.
+
+    Returns:
+        list[Section]: A  list  of  Section  objects,  each  containing  its  own lines,
+            heading, and any subsections.
+    """
+    current_section = Section()
+    sections: list[Section] = []
+    for line in lines:
+        if len(line.strip()) == 0:
+            sections.append(current_section)
+            current_section = Section()
+            continue
+        heading = __get_google_doc_heading(line)
+        if heading:
+            sections.append(current_section)
+            current_section = Section(title_summary_section=False, heading=heading)
+            continue
+        if current_section.title_summary_section:
+            current_section.lines.append(line)
+            continue
+        heading, rest_of_line = __is_parameter_explaining(line)
+        if heading is None or rest_of_line is None:
+            if len(current_section.list_elements) == 0:
+                current_section.lines.append(line)
+            else:
+                current_section.list_elements[-1].lines.append(line)
+        else:
+            current_section.list_elements.append(
+                ListElement(heading=heading, lines=[rest_of_line])
+            )
+    sections.append(current_section)
+    return [s for s in sections if len(s.lines) > 0 or s.heading is not None]
+
+
+def __single_line_docstring(
+    lines: list[str],
+    indentation_level: int,
+) -> str:
+    """Formats the docstring lines into a single line string.
+
+    Args:
+        lines (list[str]): The lines of the docstring.
+        indentation_level (int): The  level  of indentation (each level corresponds to 4
+            spaces).
+
+    Returns:
+        str: A single-line docstring string.
+    """
+    text = "\n".join(lines)
+    text = text.rstrip().rstrip('"')
+    words = text.split()
+    words[-1] += '"""'
+    indent = " " * indentation_level * 4
+    return indent + " ".join(words)
+
+
+def apply_google_style(
+    lines: list[str], indentation_level: int, line_length: int, justify: bool
+) -> list[str]:
+    """Applies Google-style formatting to the given docstring lines.
+
+    Args:
+        lines (list[str]): The raw lines of the docstring to format.
+        indentation_level (int): The level of indentation (4 spaces per level).
+        line_length (int): The maximum length of each line.
+        justify (bool): Whether to justify the text or not.
+
+    Returns:
+        list[str]: A   list   of   formatted   docstring  lines  following  Google-style
+            formatting.
+    """
+    single_line_comment = __single_line_docstring(lines, indentation_level)
+    has_multiple_periods = "." in single_line_comment.rstrip('"').rstrip().rstrip(".")
+    if len(single_line_comment) <= line_length and not has_multiple_periods:
+        return [single_line_comment]
+    lines = lines[:-1]
+    sections = __divide_into_sections(lines)
+    result = []
+    normal_indent = " " * indentation_level * 4
+    first_indent = normal_indent + " " * 4
+    second_indent = first_indent + " " * 4
+    for section in sections:
+        if section.title_summary_section:
+            result += format_text_with_prefix(
+                text="\n".join(section.lines),
+                prefix=normal_indent,
+                line_length=line_length,
+                justify=justify,
+            )
+            result.append("")
+            continue
+        result.append(f"{normal_indent}{section.heading.strip()}")
+        result += format_text_with_prefix(
+            text="\n".join(section.lines),
+            prefix=first_indent,
+            line_length=line_length,
+            justify=justify,
+        )
+        for element in section.list_elements:
+            element_text = "\n".join(element.lines)
+            first_line = format_text_with_prefix(
+                text=element_text,
+                prefix=first_indent + element.heading + " ",
+                line_length=line_length,
+                justify=justify,
+            )[0]
+            result.append(first_line)
+            words = first_line.strip()[len(element.heading) :].split()
+            all_words = element_text.split()
+            text_remaining = " ".join(all_words[len(words) :])
+            other_lines = format_text_with_prefix(
+                text=text_remaining,
+                prefix=second_indent,
+                line_length=line_length,
+                justify=justify,
+            )
+            result += other_lines
+        result.append("")
+    while result[-1] == "":
+        result.pop()
+    result.append(f'{normal_indent}"""')
+    return result

--- a/colint/docformat/docformat.py
+++ b/colint/docformat/docformat.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from ..params.black_params import BlackParams
+from .format_commented_lines import format_commented_lines
+from .format_docstring import format_script_docstrings
+
+
+def docformat(path: Path | str, params: BlackParams):
+    """Formats docstring and commented lines of a file.
+
+    **Experimental** Reads and rewrites the input file so that docstrings and commented
+    lines follow the google docstring guide lines.
+
+    Args:
+        path (Path | str): The path to the file that you wish to reformat.
+        params (BlackParams): Parameters for configuring the formatter.
+    """
+    path = Path(path)
+    format_commented_lines(path, params.line_length)
+    format_script_docstrings(path, params.line_length)

--- a/colint/docformat/format_commented_lines.py
+++ b/colint/docformat/format_commented_lines.py
@@ -1,0 +1,95 @@
+import ast
+from pathlib import Path
+
+from .format_text import format_text_with_prefix
+
+
+def __find_commented_lines(script: str) -> set[int]:
+    """Return the set of line numbers that are fully commented in the provided script.
+
+    Args:
+        script (str): The Python script as a single string.
+
+    Returns:
+        set[int]: A set of line numbers (0-indexed) that are fully commented.
+    """
+    tree = ast.parse(script)
+    code_lines = {node.lineno for node in ast.walk(tree) if hasattr(node, "lineno")}
+    return {
+        idx
+        for idx, line in enumerate(script.splitlines())
+        if idx + 1 not in code_lines and line.lstrip().startswith("#")
+    }
+
+
+def __format_commented_line(line: str, line_length: int) -> str:
+    """Format a commented line and optionally justifying its content.
+
+    Args:
+        line (str): The original commented line to be formatted.
+        line_length (int): The desired maximum line length for formatting.
+        justify (bool): Whether or not to justify the content of the line.
+
+    Returns:
+        str: The reformatted commented line.
+    """
+    if not line.lstrip().startswith("#"):
+        return line
+    whitespaces = line.split("#")[0]
+    length_whitespaces = whitespaces.count("\t") * 4 + whitespaces.count(" ")
+    indent_level = length_whitespaces // 4
+    line_content = line.split("#")[1].strip()
+    formatted_lines = format_text_with_prefix(
+        text=line_content,
+        prefix=" " * indent_level * 4 + "# ",
+        line_length=line_length,
+        justify=False,
+    )
+    return "\n".join(formatted_lines)
+
+
+def get_formatted_commented_lines_script(script: str, line_length: int) -> str:
+    """Format all fully commented lines in a Python script.
+
+    Args:
+        script (str): The Python script file to be processed.
+        line_length (int): The maximum length for each line after formatting.
+
+    Returns:
+        str: The reformatted script.
+    """
+    commented_lines_idx = __find_commented_lines(script)
+    new_lines = []
+    for idx, line in enumerate(script.splitlines()):
+        if idx in commented_lines_idx:
+            new_lines.append(__format_commented_line(line, line_length))
+        else:
+            new_lines.append(line)
+    new_script = "\n".join(new_lines)
+    while new_script[-1] == "\n" and len(new_script) > 0:
+        new_script = new_script[:-1]
+    new_script += "\n"
+    return new_script
+
+
+def format_commented_lines(
+    script_path: Path,
+    line_length: int,
+):
+    """Format all fully commented lines in a Python script file at the given path.
+
+    Args:
+        script_path (Path): The path to the Python script file to be processed.
+        line_length (int): The maximum length for each line after formatting.
+
+    Raises:
+        FileNotFoundError: If the specified file does not exist.
+    """
+    if not script_path.is_file():
+        abs_path = str(script_path.absolute())
+        raise FileNotFoundError(f"File {abs_path} not found.")
+    with script_path.open("r") as f:
+        script = f.read()
+    new_script = get_formatted_commented_lines_script(script, line_length)
+    with script_path.open("w+") as f:
+        f.write(new_script)

--- a/colint/docformat/format_docstring.py
+++ b/colint/docformat/format_docstring.py
@@ -1,0 +1,257 @@
+import ast
+import re
+from pathlib import Path
+
+from .apply_google_style import apply_google_style
+
+__docstring_pattern = re.compile(r"(\"\"\".*?\"\"\"|'''.*?''')", re.DOTALL)
+
+
+def __is_docstring(node: ast.AST) -> bool:
+    """Check if the given AST node is a docstring node.
+
+    Args:
+        node (ast.AST): An Abstract Syntax Tree (AST) node.
+
+    Returns:
+        bool: True if the node is a docstring, False otherwise.
+    """
+    return isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant)
+
+
+def __should_add_indent(node: ast.AST) -> bool:
+    """Check if the given AST node should cause an increase in indentation level.
+
+    Args:
+        node (ast.AST): An AST node.
+
+    Returns:
+        bool: True if the node represents a control structure or block, False otherwise.
+    """
+    return isinstance(
+        node,
+        (ast.FunctionDef, ast.ClassDef, ast.For, ast.If, ast.While, ast.With, ast.Try),
+    )
+
+
+def __calculate_indentation_levels(script: str) -> dict[int, int]:
+    """Calculate indentation levels for each line of the given Python script.
+
+    Args:
+        script (str): The Python script as a string.
+
+    Returns:
+        dict[int, int]: A   dictionary  mapping  line  numbers  to  their  corresponding
+            indentation levels.
+    """
+    tree = ast.parse(script)
+    indentation_levels = {}
+
+    def walk(node, level):
+        for child in ast.iter_child_nodes(node):
+            should_add_indent = __should_add_indent(child)
+            if hasattr(child, "lineno") and child.lineno not in indentation_levels:
+                indentation_levels[child.lineno] = (level, should_add_indent)
+
+            if should_add_indent:
+                walk(child, level + 1)
+            else:
+                walk(child, level)
+
+    walk(tree, 0)
+
+    return indentation_levels
+
+
+def __extract_docstrings(script: str) -> list[tuple[int, int]]:
+    """Extract the positions of docstrings in the given Python script.
+
+    Args:
+        script (str): The Python script as a string.
+
+    Returns:
+        list[tuple[int, int]]: A  list of tuples representing the start and end lines of
+            each docstring.
+    """
+    tree = ast.parse(script)
+
+    docstring_lines = list()
+
+    for node in ast.walk(tree):
+        if __is_docstring(node):
+            start_lineno = node.lineno
+            end_lineno = node.end_lineno
+            docstring_lines.append((start_lineno - 1, end_lineno - 1))
+    return docstring_lines
+
+
+def __split_into_paragraphs(text: str) -> list[str]:
+    """Split a block of text into paragraphs based on empty lines.
+
+    Args:
+        text (str): A block of text.
+
+    Returns:
+        list[str]: A  list  of paragraphs (strings) where each paragraph is separated by
+            empty lines.
+    """
+    lines = text.splitlines()
+
+    paragraphs = []
+    current_paragraph = []
+    empty_line_count = 0
+
+    for line in lines:
+        if line.strip() == "":
+            empty_line_count += 1
+        else:
+            empty_line_count = 0
+
+        if empty_line_count >= 1:
+            if current_paragraph:
+                paragraphs.append("\n".join(current_paragraph))
+                current_paragraph = []
+            empty_line_count = 0
+        else:
+            if line.strip() != "":
+                current_paragraph.append(line)
+    if current_paragraph:
+        paragraphs.append("\n".join(current_paragraph))
+
+    return paragraphs
+
+
+def __format_docstring(docstring: str) -> list[str]:
+    """Format a docstring and organize its content.
+
+    Remove the surrounding triple quotes and organize content into paragraphs.
+
+    Args:
+        docstring (str): The original docstring including triple quotes.
+
+    Returns:
+        list[str]: A list of formatted docstring lines.
+    """
+    docstring_content = docstring[3:-3].strip()
+    if len(docstring_content) == 0:
+        return ""
+    new_docstring = '"' * 3 + docstring_content + "\n" + '"' * 3
+
+    paragraphs = __split_into_paragraphs(new_docstring)
+    result = []
+
+    for k, p in enumerate(paragraphs):
+        if k > 0:
+            result.append("")
+        result += p.splitlines()
+    return result
+
+
+def __format_complete_docstring(
+    docstring_text: str,
+    indent_node: tuple[int, bool],
+) -> tuple[list[str], list[str], int]:
+    """Format a complete docstring, get indentation and extract the docstring content.
+
+    It  removes  empty docstrings, merge consecutive docstrings, and handle what happens
+    if docstring starts on a non-empty line.
+
+    Args:
+        docstring_text (str): The docstring text to format.
+        indent_node (tuple[int, bool]): A  tuple  containing  the  indentation level and
+            whether to increase it.
+
+    Returns:
+        tuple[list[str], list[str], int]: A   tuple  containing  the  lines  before  the
+            docstring, the formatted docstring, and the updated indentation level.
+    """
+    indent_level, indent_adder = indent_node
+
+    docstring_matches = list(__docstring_pattern.finditer(docstring_text))
+    if len(docstring_matches) == 0:
+        return ([docstring_text], [], indent_level)
+    idx = docstring_matches[0].start()
+    str_start = docstring_text[:idx].strip()
+    if len(str_start) > 0:
+        new_indent_level = indent_level + 1 if indent_adder else indent_level
+        actual_docstrings = __format_complete_docstring(
+            docstring_text[idx:], (new_indent_level, False)
+        )[1]
+        return ([docstring_text[:idx]], actual_docstrings, new_indent_level)
+    if len(docstring_matches) > 1:
+        docstring_contents = [
+            match.group()[3:-3].strip() for match in docstring_matches
+        ]
+        docstring_contents = [text for text in docstring_contents if len(text) > 0]
+        text = '"' * 3 + "\n\n".join(docstring_contents) + "\n" + '"' * 3
+    else:
+        text = docstring_matches[0].group().strip()
+    return ([], __format_docstring(text), indent_level)
+
+
+def get_formatted_docstring_script(script: str, line_length: int) -> str:
+    """Returns a python script after reformatting its docstrings.
+
+    This function reads a Python script, identifies all the docstrings, and formats them
+    according to the specified line length and justification preferences. It returns the
+    formatted script.
+
+    Args:
+        script (str): The Python script to format.
+        line_length (int): The maximum length for each line in the formatted docstrings.
+
+    Returns:
+        str: The reformatted script.
+    """
+    script_lines = script.splitlines()
+    docstrings_idx = __extract_docstrings(script)
+    indentation_levels = __calculate_indentation_levels(script)
+    for a, b in docstrings_idx[::-1]:
+        prefix_docstring, docstring, actual_indentation = __format_complete_docstring(
+            "\n".join(script_lines[a : b + 1]),
+            indentation_levels[a + 1],
+        )
+        formatted_docstring = []
+        if len(docstring) > 0:
+            formatted_docstring = apply_google_style(
+                lines=docstring,
+                indentation_level=actual_indentation,
+                line_length=line_length,
+            )
+        script_lines = (
+            script_lines[:a]
+            + prefix_docstring
+            + formatted_docstring
+            + script_lines[b + 1 :]
+        )
+    new_script = "\n".join([line.rstrip() for line in script_lines])
+    while new_script[-1] == "\n" and len(new_script) > 0:
+        new_script = new_script[:-1]
+    new_script += "\n"
+    return new_script
+
+
+def format_script_docstrings(script_path: Path, line_length: int):
+    """Format all the docstrings in a Python script to follow Google style guidelines.
+
+    This  function  reads  a  Python  script from the specified path, identifies all the
+    docstrings,   and   formats   them  according  to  the  specified  line  length  and
+    justification  preferences.  After  formatting,  the  script  is  saved  back to the
+    original file.
+
+    Args:
+        script_path (Path): The path to the Python script to format.
+        line_length (int): The maximum length for each line in the formatted docstrings.
+
+    Raises:
+        FileNotFoundError: If  the  specified script file does not exist at the provided
+            path.
+    """
+    if not script_path.is_file():
+        abs_path = str(script_path.absolute())
+        raise FileNotFoundError(f"File {abs_path} not found.")
+    with script_path.open("r") as f:
+        script = f.read()
+    new_script = get_formatted_docstring_script(script, line_length)
+    with script_path.open("w+") as f:
+        f.write(new_script)

--- a/colint/docformat/format_text.py
+++ b/colint/docformat/format_text.py
@@ -1,0 +1,59 @@
+import warnings
+
+
+def __format_multiline_text(text: str, width: int) -> list[str]:
+    """Formats the input text into lines of specified width with optional justification.
+
+    Args:
+        text (str): The input text to be formatted.
+        width (int): The maximum width of each line.
+
+    Returns:
+        list[str]: A  list  of  strings where each string represents a formatted line of
+            text.
+    """
+    words = text.split()
+    lines = []
+    current_line = []
+    current_length = 0
+
+    for word in words:
+        if current_length == 0 and len(word) >= width:
+            lines.append(word)
+            continue
+        if current_length + len(word) + len(current_line) > width:
+            lines.append(" ".join(current_line).ljust(width))
+            current_line = []
+            current_length = 0
+
+        current_line.append(word)
+        current_length += len(word)
+
+    lines.append(" ".join(current_line).ljust(width))
+
+    return lines
+
+
+def format_text_with_prefix(text: str, prefix: str, line_length: int) -> list[str]:
+    """Formats text into lines of specified length and adds a prefix to each line.
+
+    Args:
+        text (str): The input text to be formatted.
+        prefix (str): A string to be added at the beginning of each line.
+        line_length (int): The total length of each line, including the prefix.
+
+    Returns:
+        list[str]: A list of formatted lines, each prefixed with the given prefix.
+
+    Raises:
+        Warning: If  the  prefix  length  makes  the  remaining line width too small for
+            proper formatting a warning is issued and the unformatted text is returned.
+    """
+    if len(text.strip()) == 0:
+        return []
+    width = line_length - len(prefix)
+    if width < 10:
+        warnings.warn("Prefix too big: returning text without formatting")
+        return text
+    justified_lines = __format_multiline_text(text, width)
+    return [prefix + line for line in justified_lines]


### PR DESCRIPTION
`docformat` is able to reformat docstrings and commented lines to adhere the google docstring format.

This feature is experimental and it will needs some fixes in the future.