### PR TITLE
Update Google-Style Docstrings Keywords

### DIFF
--- a/src/colint/docformat/apply_google_style.py
+++ b/src/colint/docformat/apply_google_style.py
@@ -47,17 +47,20 @@ class Section:
 
 __google_docs_section_keys = [
     "Args",
-    "Returns",
-    "Raises",
     "Attributes",
-    "Yields",
-    "Examples",
-    "See Also",
-    "Notes",
-    "Warnings",
-    "References",
     "Deprecated",
+    "Examples",
+    "Methods",
+    "Notes",
+    "Overridden",
+    "Properties",
+    "Raises",
+    "References",
+    "Returns",
+    "See Also",
     "TODO",
+    "Warnings",
+    "Yields",
 ]
 
 __google_docs_section_patterns = [


### PR DESCRIPTION
Adds "Methods", "Properties", "Overridden" non-standard keywords to the list of supported keywords.